### PR TITLE
Fix depositTx type

### DIFF
--- a/chain/chain_config.go
+++ b/chain/chain_config.go
@@ -240,6 +240,22 @@ func (c *Config) IsEip1559FeeCollector(num uint64) bool {
 	return c.Eip1559FeeCollector != nil && isForked(c.Eip1559FeeCollectorTransition, num)
 }
 
+// BaseFeeChangeDenominator bounds the amount the base fee can change between blocks.
+func (c *Config) BaseFeeChangeDenominator(defaultParam int) uint64 {
+	if c.IsOptimism() {
+		return c.Optimism.EIP1559Denominator
+	}
+	return uint64(defaultParam)
+}
+
+// ElasticityMultiplier bounds the maximum gas limit an EIP-1559 block may have.
+func (c *Config) ElasticityMultiplier(defaultParam int) uint64 {
+	if c.IsOptimism() {
+		return c.Optimism.EIP1559Elasticity
+	}
+	return uint64(defaultParam)
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *Config) CheckCompatible(newcfg *Config, height uint64) *ConfigCompatError {

--- a/types/txn.go
+++ b/types/txn.go
@@ -174,7 +174,7 @@ func (ctx *TxParseContext) ParseTransaction(payload []byte, pos int, slot *TxSlo
 	// If it is non-legacy transaction, the transaction type follows, and then the the list
 	if !legacy {
 		slot.Type = payload[p]
-		if slot.Type > BlobTxType {
+		if slot.Type > BlobTxType && slot.Type != DepositTxType {
 			return 0, fmt.Errorf("%w: unknown transaction type: %d", ErrParseTxn, slot.Type)
 		}
 		p++


### PR DESCRIPTION
This fix makes sure that `ParseTransaction` returns the right `p` for the `depositTx`