### PR TITLE
Have txpool respect basefee

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -174,6 +174,10 @@ func SortByNonceLess(a, b *metaTx) bool {
 }
 
 func calcProtocolBaseFee(baseFee uint64) uint64 {
+	// TODO(jky) What is going on here? Why was this returning a constant 7?
+	if baseFee < 7 {
+		return baseFee
+	}
 	return 7
 }
 


### PR DESCRIPTION
I'm very unsure why the 'protocol fee' is fixed at 7, even though it takes the base fee as a parameter.  This feels like a parameter which is not required for consensus, but also hasn't been fully implemented in Erigon yet.  But, should be investigated.

As this is in the txpool, which should have no real impact on 'correctness' of the blockchain, I'd like to merge this sooner to get our tests working, and will investigate why exactly '7' is being returned here in the normal case.